### PR TITLE
Migrate daily pun scheduler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ dev_guild_id=0
 prefix=%
 log_level=INFO
 lead_dev_user_id=0
+general_channel_id=0
 toes_url=
 yoshimaru_url=
 mongo_connection_string=mongodb://localhost:27017

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This project requires Python 3.11 or newer.
    prefix=%
    log_level=INFO
    lead_dev_user_id=0
+   general_channel_id=0
    toes_url=
    yoshimaru_url=
    mongo_connection_string=mongodb://localhost:27017
@@ -51,6 +52,7 @@ This project requires Python 3.11 or newer.
    ```
 
 Only `discord_token` is required; the other values fall back to defaults or may be left empty where applicable.
+Set `general_channel_id` to enable the daily 4:20 PM America/Chicago pun post in that channel.
 
 The Python bot stores self-role menus in `BeanBotPythonDB` by default, leaving the C# bot's legacy
 `BeanBotDB` untouched. An administrator can run `%rolesetting` and choose up to 20 self-assignable

--- a/docs/migration-status.md
+++ b/docs/migration-status.md
@@ -16,7 +16,7 @@ The Python migration is complete when every legacy behavior is either **Complete
 | Legacy environment variable compatibility | Complete | `core/config.py` |
 | 8-ball behavior | Partial | Basic question/response flow exists; richer validation, response overrides, queue responses, and PunMaster behavior remain |
 | Command prefixes and legacy aliases | Partial | `%` and mention prefixes work; legacy `succ ` prefix and some aliases need a product decision or implementation |
-| Automatic daily pun | Remaining | Port the scheduled America/Chicago post and configured destination channel |
+| Automatic daily pun | Complete | `features/memes/cog.py` posts at 16:20 America/Chicago to `general_channel_id` |
 | New-member direct message | Remaining | Port the non-bot member welcome/instruction handler |
 | Edited 8-ball request handling | Remaining | Track the response and replace it when the original request is edited |
 | Connection health endpoint | Remaining | Port or replace authenticated `/healthz`, readiness state, and rate limiting |
@@ -27,9 +27,8 @@ The Python migration is complete when every legacy behavior is either **Complete
 
 1. Finish 8-ball parity and decide which legacy aliases are still supported.
 2. Add member-join and message-edit event features.
-3. Add the daily-pun scheduler with timezone-aware tests.
-4. Define the deployment health contract, then implement the smallest endpoint that satisfies it.
-5. Run a Discord staging-server parity checklist and mark the remaining rows complete or retired.
+3. Define the deployment health contract, then implement the smallest endpoint that satisfies it.
+4. Run a Discord staging-server parity checklist and mark the remaining rows complete or retired.
 
 The role-menu migration does not mutate `BeanBotDB.roleSettings`. It copies valid documents into
 the separately configured Python database and collection. See [role-menus.md](role-menus.md) for

--- a/src/beanbot/core/config.py
+++ b/src/beanbot/core/config.py
@@ -19,6 +19,14 @@ class Settings(BaseSettings):
     prefix: str = "%"
     log_level: str = "INFO"
     lead_dev_user_id: int = 0
+    general_channel_id: int = Field(
+        default=0,
+        validation_alias=AliasChoices(
+            "general_channel_id",
+            "BEANBOT_GENERAL_CHANNEL_ID",
+            "generalChannelId",
+        ),
+    )
     toes_url: str | None = Field(
         default=None,
         validation_alias=AliasChoices("toes_url", "BEANBOT_HATOETE_URL", "hatoeteUrl"),

--- a/src/beanbot/features/memes/cog.py
+++ b/src/beanbot/features/memes/cog.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime as dt
 import io
 import logging
 import random
@@ -8,16 +9,74 @@ from contextlib import suppress
 from dataclasses import dataclass
 from importlib import resources
 from typing import Final
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import aiohttp
 import discord
-from discord.ext import commands
+from discord.ext import commands, tasks
 
 from beanbot.discord.bot import BeanBot
 from beanbot.features.memes.api import MemeApiClient, MemeApiError
 from beanbot.features.memes.puns import PunRepository
 
 log = logging.getLogger(__name__)
+
+
+class _FallbackChicagoTimeZone(dt.tzinfo):
+    _STANDARD_OFFSET: Final[dt.timedelta] = dt.timedelta(hours=-6)
+    _DST_OFFSET: Final[dt.timedelta] = dt.timedelta(hours=-5)
+    _DST_DELTA: Final[dt.timedelta] = dt.timedelta(hours=1)
+
+    def utcoffset(self, value: dt.datetime | None) -> dt.timedelta | None:
+        if value is None:
+            return None
+        return self._DST_OFFSET if self._is_dst(value.replace(tzinfo=None)) else self._STANDARD_OFFSET
+
+    def dst(self, value: dt.datetime | None) -> dt.timedelta | None:
+        if value is None:
+            return None
+        return self._DST_DELTA if self._is_dst(value.replace(tzinfo=None)) else dt.timedelta(0)
+
+    def tzname(self, value: dt.datetime | None) -> str:
+        if value is not None and self._is_dst(value.replace(tzinfo=None)):
+            return "CDT"
+        return "CST"
+
+    def fromutc(self, value: dt.datetime) -> dt.datetime:
+        if value.tzinfo is not self:
+            raise ValueError("fromutc: dt.tzinfo is not self")
+        standard_time = value.replace(tzinfo=None) + self._STANDARD_OFFSET
+        if self._is_dst(standard_time):
+            standard_time += self._DST_DELTA
+        return standard_time.replace(tzinfo=self)
+
+    @classmethod
+    def _is_dst(cls, value: dt.datetime) -> bool:
+        start = cls._nth_weekday(value.year, 3, 6, 2).replace(hour=2)
+        end = cls._nth_weekday(value.year, 11, 6, 1).replace(hour=2)
+        return start <= value < end
+
+    @staticmethod
+    def _nth_weekday(year: int, month: int, weekday: int, occurrence: int) -> dt.datetime:
+        first = dt.datetime(year, month, 1)
+        days_until_weekday = (weekday - first.weekday()) % 7
+        day = 1 + days_until_weekday + (occurrence - 1) * 7
+        return dt.datetime(year, month, day)
+
+
+def _load_chicago_timezone() -> dt.tzinfo:
+    try:
+        return ZoneInfo("America/Chicago")
+    except ZoneInfoNotFoundError:
+        return _FallbackChicagoTimeZone()
+
+
+DAILY_PUN_TIMEZONE: Final[dt.tzinfo] = _load_chicago_timezone()
+DAILY_PUN_POST_TIME: Final[dt.time] = dt.time(hour=16, minute=20, tzinfo=DAILY_PUN_TIMEZONE)
+DAILY_PUN_INTRO: Final[str] = (
+    "The time has come and so have I, Bean Bot here to deliver you your daily pun(?)"
+)
+DAILY_PUN_EMOTE: Final[str] = "<:420stolfoit:675553715759087618>"
 
 
 def _is_question(text: str) -> bool:
@@ -60,6 +119,7 @@ def _uwuify(text: str) -> str:
 class MemeConfig:
     toes_url: str | None = None
     yoshimaru_url: str | None = None
+    daily_pun_channel_id: int = 0
 
 
 class MemeCog(commands.Cog, name="Meme Commands"):
@@ -91,6 +151,56 @@ class MemeCog(commands.Cog, name="Meme Commands"):
         self.bot = bot
         self.config = config or MemeConfig()
         self.pun_repo = pun_repo or PunRepository()
+
+    async def cog_load(self) -> None:
+        if not self.config.daily_pun_channel_id:
+            log.info("Daily pun scheduler disabled; no destination channel configured")
+            return
+
+        if not self.daily_pun_scheduler.is_running():
+            self.daily_pun_scheduler.start()
+            log.info(
+                "Daily pun scheduler enabled for channel=%s at %s America/Chicago",
+                self.config.daily_pun_channel_id,
+                DAILY_PUN_POST_TIME.strftime("%H:%M"),
+            )
+
+    async def cog_unload(self) -> None:
+        self.daily_pun_scheduler.cancel()
+
+    @tasks.loop(time=DAILY_PUN_POST_TIME)
+    async def daily_pun_scheduler(self) -> None:
+        await self._post_daily_pun()
+
+    @daily_pun_scheduler.before_loop
+    async def before_daily_pun_scheduler(self) -> None:
+        await self.bot.wait_until_ready()
+
+    async def _post_daily_pun(self) -> None:
+        channel_id = self.config.daily_pun_channel_id
+        if not channel_id:
+            return
+
+        channel = self.bot.get_channel(channel_id)
+        if channel is None:
+            try:
+                channel = await self.bot.fetch_channel(channel_id)
+            except (discord.Forbidden, discord.NotFound, discord.HTTPException):
+                log.exception("Could not fetch daily pun channel: channel=%s", channel_id)
+                return
+
+        send = getattr(channel, "send", None)
+        if send is None:
+            log.error("Configured daily pun channel is not messageable: channel=%s", channel_id)
+            return
+
+        log.info("Posting daily pun to channel=%s", channel_id)
+        try:
+            await send(DAILY_PUN_INTRO, allowed_mentions=_safe_allowed_mentions())
+            await send(DAILY_PUN_EMOTE, allowed_mentions=_safe_allowed_mentions())
+            await send(self.pun_repo.get_random_pun(), allowed_mentions=_safe_allowed_mentions())
+        except discord.HTTPException:
+            log.exception("Could not post daily pun: channel=%s", channel_id)
 
     @commands.hybrid_command(
         name="succ",
@@ -319,5 +429,6 @@ async def setup(bot: BeanBot) -> None:
     config = MemeConfig(
         toes_url=bot.settings.toes_url,
         yoshimaru_url=bot.settings.yoshimaru_url,
+        daily_pun_channel_id=bot.settings.general_channel_id,
     )
     await bot.add_cog(MemeCog(bot, config=config, pun_repo=PunRepository()))

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -8,10 +8,12 @@ from beanbot.core.config import Settings
 def test_settings_accept_legacy_csharp_environment_names(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("BEANBOT_BOT_TOKEN", "token")
     monkeypatch.setenv("BEANBOT_MONGO_CONNECTION_STRING", "mongodb://mongo:27017")
+    monkeypatch.setenv("BEANBOT_GENERAL_CHANNEL_ID", "123")
     monkeypatch.setenv("BEANBOT_HATOETE_URL", "https://example.test/toes.png")
 
     settings = Settings(_env_file=None)
 
     assert settings.discord_token == "token"
     assert settings.mongo_connection_string == "mongodb://mongo:27017"
+    assert settings.general_channel_id == 123
     assert settings.toes_url == "https://example.test/toes.png"

--- a/tests/unit/features/memes/test_cog.py
+++ b/tests/unit/features/memes/test_cog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
 from types import SimpleNamespace
 from typing import Any
 
@@ -15,6 +16,34 @@ class FakeContext:
 
     async def reply(self, *args: Any, **kwargs: Any) -> None:
         self.replies.append((args, kwargs))
+
+
+class FakePunRepository:
+    def get_random_pun(self) -> str:
+        return "a migrated pun"
+
+
+class FakeTextChannel:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    async def send(self, content: str, **kwargs: Any) -> None:
+        self.messages.append(content)
+
+
+class FakeBot:
+    def __init__(self, channel: FakeTextChannel | None = None) -> None:
+        self.http_session = object()
+        self.channel = channel
+        self.fetch_count = 0
+
+    def get_channel(self, channel_id: int) -> FakeTextChannel | None:
+        return self.channel
+
+    async def fetch_channel(self, channel_id: int) -> FakeTextChannel:
+        self.fetch_count += 1
+        assert self.channel is not None
+        return self.channel
 
 
 def test_meme_command_fetches_and_replies_with_embed(monkeypatch: Any) -> None:
@@ -55,3 +84,56 @@ def test_uwu_command_does_not_run_meme_fetch_logic(monkeypatch: Any) -> None:
 
     assert context.replies[0][0] == ("uwu:beans",)
     assert len(context.replies) == 1
+
+
+def test_daily_pun_posts_legacy_message_sequence() -> None:
+    channel = FakeTextChannel()
+    cog = meme_cog.MemeCog(
+        FakeBot(channel),
+        config=meme_cog.MemeConfig(daily_pun_channel_id=123),
+        pun_repo=FakePunRepository(),
+    )
+
+    asyncio.run(cog._post_daily_pun())
+
+    assert channel.messages == [
+        meme_cog.DAILY_PUN_INTRO,
+        meme_cog.DAILY_PUN_EMOTE,
+        "a migrated pun",
+    ]
+
+
+def test_daily_pun_fetches_channel_when_not_cached() -> None:
+    channel = FakeTextChannel()
+    bot = FakeBot(channel)
+    bot.channel = None
+
+    async def fetch_channel(channel_id: int) -> FakeTextChannel:
+        bot.fetch_count += 1
+        return channel
+
+    bot.fetch_channel = fetch_channel
+    cog = meme_cog.MemeCog(
+        bot,
+        config=meme_cog.MemeConfig(daily_pun_channel_id=123),
+        pun_repo=FakePunRepository(),
+    )
+
+    asyncio.run(cog._post_daily_pun())
+
+    assert bot.fetch_count == 1
+    assert channel.messages[-1] == "a migrated pun"
+
+
+def test_daily_pun_schedule_uses_chicago_420_pm_with_dst() -> None:
+    schedule_time = meme_cog.DAILY_PUN_POST_TIME
+
+    assert schedule_time.hour == 16
+    assert schedule_time.minute == 20
+    assert schedule_time.tzinfo is meme_cog.DAILY_PUN_TIMEZONE
+
+    winter = dt.datetime(2026, 1, 1, 16, 20, tzinfo=schedule_time.tzinfo)
+    summer = dt.datetime(2026, 7, 1, 16, 20, tzinfo=schedule_time.tzinfo)
+
+    assert winter.utcoffset() == dt.timedelta(hours=-6)
+    assert summer.utcoffset() == dt.timedelta(hours=-5)


### PR DESCRIPTION
## Summary
- Adds the daily pun scheduler to the meme cog at 4:20 PM America/Chicago.
- Reuses the existing pun repository and posts the legacy three-message sequence to the configured general channel.
- Adds `general_channel_id` / `BEANBOT_GENERAL_CHANNEL_ID` settings support and updates operator docs.
- Marks the automatic daily pun migration item complete.

## Impact
The scheduler is disabled by default until `general_channel_id` is configured. Once configured, the bot posts the daily pun sequence to that channel after the Discord client is ready.

## Validation
- `python -m pytest`
- `python -m ruff check src tests`
- `python -m mypy src`